### PR TITLE
If a Cinema has no showings, return an empty array.

### DIFF
--- a/lib/movies_api/find_any_film.rb
+++ b/lib/movies_api/find_any_film.rb
@@ -38,7 +38,10 @@ module MoviesApi
       url = "#{BASE_URL}/api/screenings/by_venue_id/venue_id/#{cinema_id}/" \
         "date_from/#{date}"
 
-      response = JSON.parse(Excon.get(url).body)
+      request = Excon.get(url)
+      return [] if request.body == "false"
+
+      response = JSON.parse(request.body)
 
       showings = []
 

--- a/spec/cassettes/find_cinemas_showings_empty.yml
+++ b/spec/cassettes/find_cinemas_showings_empty.yml
@@ -1,0 +1,48 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://www.findanyfilm.com/api/screenings/by_venue_id/venue_id/10403/date_from/2017-10-13
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.51.0
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Fri, 13 Oct 2017 15:33:14 GMT
+      Content-Type:
+      - application/json
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=dbc74f606b670bf5e7d87b4409cdee1bd1507908794; expires=Sat, 13-Oct-18
+        15:33:14 GMT; path=/; domain=.findanyfilm.com; HttpOnly; Secure, findanyfilm=0sf6dngf2nf1um0acq1fc7aoqc4irih6;
+        expires=Fri, 13-Oct-2017 17:33:14 GMT; Max-Age=7200; path=/; HttpOnly
+      Cache-Control:
+      - no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      P3p:
+      - CP="ALL ADM DEV PSAi COM OUR OTRo STP IND ONL"
+      Pragma:
+      - no-cache
+      Vary:
+      - Accept-Encoding
+      X-Powered-By:
+      - PHP/5.5.26
+      Server:
+      - cloudflare-nginx
+      Cf-Ray:
+      - 3ad35b2baaf869d1-LHR
+    body:
+      encoding: UTF-8
+      string: 'false'
+    http_version: 
+  recorded_at: Thu, 12 Oct 2017 23:00:00 GMT
+recorded_with: VCR 3.0.3

--- a/spec/movies_api/find_any_film_spec.rb
+++ b/spec/movies_api/find_any_film_spec.rb
@@ -52,6 +52,16 @@ RSpec.describe MoviesApi::FindAnyFilm do
         expect(showing.start_time).to eq(DateTime.new(2016, 11, 14, 12, 0, 0))
       end
     end
+
+    it "returns an empty array if there's no showings" do
+      VCR.use_cassette("find_cinemas_showings_empty") do
+        Timecop.freeze(2017, 10, 13) do
+          showings = faf.find_cinema_showings("10403")
+
+          expect(showings).to eq([])
+        end
+      end
+    end
   end
 
   describe "find_featured_films" do


### PR DESCRIPTION
It seems like if there's no data, FaF will return the text "false",
instead of an empty result. This causes the JSON parser to throw an
exception. Instead, we'll catch this and return early with an empty
array.