### PR TITLE
Validate that the venue_id in showings is correct.

### DIFF
--- a/lib/movies_api/app.rb
+++ b/lib/movies_api/app.rb
@@ -47,6 +47,10 @@ module MoviesApi
     # Show Listings for Cinemas
     #
     get "/cinemas/:venue_id/showings/?:date?" do
+      param :venue_id, String, required: true,
+                               format: /^([0-9]*)$/,
+                               message: "not a valid venue_id"
+
       faf = FindAnyFilm.new
       date = params[:date] || Date.today.strftime("%Y-%m-%d")
       showings = faf.find_cinema_showings(params[:venue_id], Date.parse(date))

--- a/spec/requests/showings_spec.rb
+++ b/spec/requests/showings_spec.rb
@@ -23,5 +23,12 @@ RSpec.describe "Showings" do
         expect(json[0]["time"]).to eq(["12:20", "17:45"])
       end
     end
+
+    it "validates the venue is an integer" do
+      get "/cinemas/$7955/showings"
+
+      expect(last_response).to be_bad_request
+      expect(json["message"]).to eq("not a valid venue_id")
+    end
   end
 end


### PR DESCRIPTION
A common source of errors is mangled/incorrect venue identifiers.
They're typically four numbers, but are handled as strings.