### PR TITLE
Remove Timber for logging.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,6 @@ gem "sentry-raven"
 gem "sinatra"
 gem "sinatra-contrib"
 gem "sinatra-param"
-gem "timber"
 
 group :development, :test do
   gem "pry"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,7 +31,6 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2018.0812)
     mini_portile2 (2.4.0)
-    msgpack (1.2.9)
     multi_json (1.13.1)
     multipart-post (2.0.0)
     mustermann (1.0.3)
@@ -82,8 +81,6 @@ GEM
     sinatra-param (1.6.0)
       sinatra (>= 1.3)
     tilt (2.0.9)
-    timber (3.0.1)
-      msgpack (~> 1.0)
     timecop (0.9.1)
     unf (0.1.4)
       unf_ext
@@ -109,7 +106,6 @@ DEPENDENCIES
   sinatra
   sinatra-contrib
   sinatra-param
-  timber
   timecop
   vcr
   webmock

--- a/lib/movies_api.rb
+++ b/lib/movies_api.rb
@@ -8,7 +8,6 @@ require "sinatra/param"
 require "raven"
 require "mechanize"
 require "excon"
-require "timber"
 
 require "movies_api/resource"
 require "movies_api/cinema"

--- a/lib/movies_api/app.rb
+++ b/lib/movies_api/app.rb
@@ -7,17 +7,6 @@ module MoviesApi
     helpers Sinatra::CustomLogger
     helpers Sinatra::Param
 
-    configure :development, :production do
-      logger = Timber::Logger.new(STDOUT)
-
-      logger.level = Logger::DEBUG if development?
-      set :logger, logger
-
-      Timber::Integrations::Rack.middlewares.each do |middleware|
-        use middleware
-      end
-    end
-
     before do
       # we almost always want a JSON output
       content_type :json


### PR DESCRIPTION
Logs weren't getting read, so stop reporting them to Timber.

Additionally, the public API for the Timber gem recently changed, which
caused it to stop working.