### PR TITLE
Fully validate dates passed into showings.

### DIFF
--- a/lib/movies_api/app.rb
+++ b/lib/movies_api/app.rb
@@ -39,10 +39,12 @@ module MoviesApi
       param :venue_id, String, required: true,
                                format: /^([0-9]*)$/,
                                message: "not a valid venue_id"
+      param :date, Date, required: false,
+                         default: Date.today.strftime("%Y-%m-%d"),
+                         message: "not a valid date format"
 
       faf = FindAnyFilm.new
-      date = params[:date] || Date.today.strftime("%Y-%m-%d")
-      showings = faf.find_cinema_showings(params[:venue_id], Date.parse(date))
+      showings = faf.find_cinema_showings(params[:venue_id], params[:date])
 
       # this is technically showing films, not showings
       # so, we're, badly, flipping it back to the original implementation

--- a/spec/requests/showings_spec.rb
+++ b/spec/requests/showings_spec.rb
@@ -24,6 +24,13 @@ RSpec.describe "Showings" do
       end
     end
 
+    it "responds with a client error if a date is not valid" do
+      get "/cinemas/7955/showings/1"
+
+      expect(last_response).to be_bad_request
+      expect(json["message"]).to eq("not a valid date format")
+    end
+
     it "validates the venue is an integer" do
       get "/cinemas/$7955/showings"
 


### PR DESCRIPTION
* Moves date parsing into `sinatra-param`, rather than half-doing it,
* …which adds error handling for clients.