### PR TITLE
Force moviesapi.org.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ ruby "2.6.3"
 
 gem "excon"
 gem "mechanize"
+gem "rack-canonical-host"
 gem "rake"
 gem "sentry-raven"
 gem "sinatra"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,9 @@ GEM
       method_source (~> 0.9.0)
     public_suffix (3.0.3)
     rack (2.0.6)
+    rack-canonical-host (0.2.3)
+      addressable (> 0, < 3)
+      rack (>= 1.0.0, < 3)
     rack-protection (2.0.5)
       rack
     rack-test (1.1.0)
@@ -99,6 +102,7 @@ DEPENDENCIES
   excon
   mechanize
   pry
+  rack-canonical-host
   rack-test
   rake
   rspec

--- a/config.ru
+++ b/config.ru
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
-$LOAD_PATH.push File.expand_path("../lib", __FILE__)
+
+require "rack-canonical-host"
+$LOAD_PATH.push File.expand_path("lib", __dir__)
 require "movies_api"
 
+use Rack::CanonicalHost, ENV["CANONICAL_HOST"] if ENV["CANONICAL_HOST"]
 run MoviesApi::App


### PR DESCRIPTION
Traditionally, we've just used the Heroku domain. This forcefully
redirects clients to use the custom domain.